### PR TITLE
Set ForeignKey/OneToOneField on_delete argument

### DIFF
--- a/src/django_future/migrations/0001_initial.py
+++ b/src/django_future/migrations/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('kwargs', picklefield.fields.PickledObjectField(verbose_name='kwargs', editable=False)),
                 ('error', models.TextField(null=True, verbose_name='error', blank=True)),
                 ('return_value', models.TextField(null=True, verbose_name='return value', blank=True)),
-                ('content_type', models.ForeignKey(verbose_name='content type', blank=True, to='contenttypes.ContentType', null=True)),
+                ('content_type', models.ForeignKey(on_delete=models.CASCADE, verbose_name='content type', blank=True, to='contenttypes.ContentType', null=True)),
             ],
             options={
                 'ordering': ['time_slot_start'],

--- a/src/django_future/models.py
+++ b/src/django_future/models.py
@@ -33,7 +33,8 @@ class ScheduledJob(models.Model):
             default=STATUS_SCHEDULED)
 
     content_type = models.ForeignKey(
-            ContentType, blank=True, null=True, verbose_name=_('content type'))
+            ContentType, on_delete=models.CASCADE, blank=True, null=True,
+            verbose_name=_('content type'))
 
     object_id = models.PositiveIntegerField(
             _('object ID'), blank=True, null=True)


### PR DESCRIPTION
Adds the `on_delete` argument to all ForeignKey and OneToOneField fields
for Django 2.0 compatibility. See:

https://docs.djangoproject.com/en/2.0/releases/1.9/#foreignkey-and-onetoonefield-on-delete-argument