### PR TITLE
Improve unit tests and automate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+python:
+ - "2.7"
+ - "3.6"
+
+env:
+ - DJANGO_ENV=django110
+ - DJANGO_ENV=django111
+
+install:
+ - pip install tox
+
+script:
+ - tox -e $(echo py$TRAVIS_PYTHON_VERSION-$DJANGO_ENV | tr -d .)

--- a/src/django_future/jobs.py
+++ b/src/django_future/jobs.py
@@ -1,9 +1,12 @@
 """Django-future -- scheduled jobs in Django."""
+from __future__ import unicode_literals
 
 import datetime
 import traceback
 
+from django.utils import six
 from django.utils import timezone
+from django.utils.encoding import force_text
 
 from django_future.models import ScheduledJob
 from django_future.utils import parse_timedelta
@@ -29,9 +32,9 @@ def schedule_job(date, callable_name, content_object=None, expires='7d',
     """
     # TODO: allow to pass in a real callable, but check that it's a global
     assert callable_name \
-        and isinstance(callable_name, basestring), callable_name
+        and isinstance(callable_name, six.string_types), callable_name
 
-    if isinstance(date, basestring):
+    if isinstance(date, six.string_types):
         date = parse_timedelta(date)
 
     if isinstance(date, datetime.timedelta):
@@ -40,7 +43,7 @@ def schedule_job(date, callable_name, content_object=None, expires='7d',
     job = ScheduledJob(callable_name=callable_name, time_slot_start=date)
 
     if expires:
-        if isinstance(expires, basestring):
+        if isinstance(expires, six.string_types):
             expires = parse_timedelta(expires)
         if isinstance(expires, datetime.timedelta):
             expires = date + expires
@@ -95,7 +98,7 @@ def _run_scheduled_job(job, delete_completed, ignore_errors):
         else:
             job.status = ScheduledJob.STATUS_COMPLETE
             if return_value is not None:
-                job.return_value = unicode(return_value)
+                job.return_value = force_text(return_value)
             else:
                 job.return_value = None
             job.save()

--- a/src/django_future/jobs.py
+++ b/src/django_future/jobs.py
@@ -3,8 +3,6 @@
 import datetime
 import traceback
 
-from django.core import exceptions
-from django.db import transaction
 from django.utils import timezone
 
 from django_future.models import ScheduledJob
@@ -74,9 +72,6 @@ def _expire_jobs(expire_at):
 
 
 def _run_scheduled_job(job, delete_completed, ignore_errors):
-    """
-    Assumes we're running with AUTOCOMMIT=True (Default)
-    """
     # Mark job as running
     job.status = ScheduledJob.STATUS_RUNNING
     job.execution_start = timezone.now()
@@ -111,12 +106,6 @@ def _run_scheduled_jobs(run_at, delete_completed, ignore_errors):
     The following code requires autocommit mode to be enabled. (Django's
     default)
     """
-    if not transaction.get_autocommit():
-        raise exceptions.ImproperlyConfigured("Expecting AUTOCOMMIT=True")
-
-    # Issue a commit to ensure there is no open transaction
-    transaction.commit()
-
     # Fetch scheduled jobs. Order by `time_slot_start` to ensure oldest jobs
     # run first.
     scheduled_jobs = ScheduledJob.objects.filter(

--- a/src/django_future/models.py
+++ b/src/django_future/models.py
@@ -1,11 +1,17 @@
+from __future__ import unicode_literals
+
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.utils.encoding import (
+    force_str, force_text, python_2_unicode_compatible)
+
 from django.utils.translation import ugettext_lazy as _
 
 from picklefield import PickledObjectField
 
 
+@python_2_unicode_compatible
 class ScheduledJob(models.Model):
 
     STATUS_SCHEDULED = 'scheduled'
@@ -65,11 +71,12 @@ class ScheduledJob(models.Model):
         ordering = ['time_slot_start']
 
     def __repr__(self):
-        return '<ScheduledJob (%s) callable=%r>' % (
-                    self.status, self.callable_name)
+        return force_str(
+                '<%s (%s) callable=%r>' % (
+                    type(self).__name__, self.status, self.callable_name))
 
-    def __unicode__(self):
-        return self.callable_name
+    def __str__(self):
+        return force_text(self.callable_name)
 
     def run(self):
         """

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,8 +38,6 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'tests.urls'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,78 @@
+from datetime import timedelta
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from django_future.jobs import schedule_job
+from django_future.models import ScheduledJob
+
+
+class RunScheduledJobsCommandTest(TestCase):
+
+    def setUp(self):
+        self.schedule_at = timezone.now() - timedelta(days=1)
+
+        self.jobs = [
+            schedule_job(self.schedule_at, 'math.pow', args=(2, 3)),
+            schedule_job(self.schedule_at, 'math.pow', args=(5, 2))
+        ]
+
+    def test_cmd_noargs(self):
+        """
+        Test invocation of command with no arguments. Ensure the scheduled jobs
+        are marked as completed.
+        """
+        self.assertEqual(
+            2,
+            ScheduledJob.objects.filter(
+                status=ScheduledJob.STATUS_SCHEDULED).count()
+        )
+
+        call_command('runscheduledjobs')
+
+        self.assertEqual(
+            2,
+            ScheduledJob.objects.filter(
+                status=ScheduledJob.STATUS_COMPLETE).count()
+        )
+
+    def test_cmd_delete_completed(self):
+        """
+        Test invocation of command with '-d' argument to delete completed jobs.
+        Ensure the scheduled jobs are removed after.
+        """
+        self.assertEqual(
+            2,
+            ScheduledJob.objects.filter(
+                status=ScheduledJob.STATUS_SCHEDULED).count()
+        )
+
+        call_command('runscheduledjobs', '-d')
+
+        self.assertEqual(0, ScheduledJob.objects.count())
+
+    def test_cmd_ignore_errors(self):
+        """
+        Test invocation of command with '-i' argument to keep processing jobs
+        even if a job fails. Ensure the non-failing jobs are marked as
+        completed and the error job is marked as failed.
+        """
+        schedule_at = self.schedule_at - timedelta(days=1)
+        error_job = schedule_job(schedule_at, 'math.funky_error')
+
+        self.assertEqual(
+            3,
+            ScheduledJob.objects.filter(
+                status=ScheduledJob.STATUS_SCHEDULED).count()
+        )
+
+        call_command('runscheduledjobs', '-i')
+
+        error_job.refresh_from_db()
+        self.assertEqual(error_job.status, ScheduledJob.STATUS_FAILED)
+
+        self.assertEqual(
+            2,
+            ScheduledJob.objects.filter(
+                status=ScheduledJob.STATUS_COMPLETE).count()
+        )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,5 +1,7 @@
-from datetime import datetime
+from datetime import timedelta
+
 from django.test import TransactionTestCase
+from django.utils import timezone
 
 from django_future.jobs import (schedule_job, run_jobs, _expire_jobs,
                                 _run_scheduled_jobs)
@@ -8,50 +10,55 @@ from django_future.models import ScheduledJob
 
 class JobsTestCase(TransactionTestCase):
 
+    def setUp(self):
+        self.now = timezone.now()
+
     def test_expire_jobs(self):
-        job = schedule_job(datetime(1970, 1, 1), 'math.pow', args=(2, 3))
+        job = schedule_job(
+                self.now - timedelta(hours=1), 'math.pow', args=(2, 3))
         self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)
 
-        _expire_jobs(datetime(1980, 1, 1))
+        _expire_jobs(self.now + timedelta(days=60))
 
-        self.assertEqual(
-            ScheduledJob.objects.get(pk=job.pk).status,
-            ScheduledJob.STATUS_EXPIRED)
+        job.refresh_from_db()
+        self.assertEqual(job.status, ScheduledJob.STATUS_EXPIRED)
 
     def test_run_scheduled_jobs(self):
-        job1 = schedule_job(datetime(1970, 1, 1), 'math.pow', args=(2, 2))
-        job2 = schedule_job(datetime(1970, 1, 2), 'math.pow', args=(2, 3))
+        job1 = schedule_job(
+                self.now - timedelta(hours=2), 'math.pow', args=(2, 2))
+        job2 = schedule_job(
+                self.now - timedelta(hours=1), 'math.pow', args=(2, 3))
 
-        _run_scheduled_jobs(datetime(1970, 1, 3), False, False)
+        _run_scheduled_jobs(self.now, False, False)
 
-        result_job1 = ScheduledJob.objects.get(pk=job1.pk)
-        self.assertEqual(result_job1.status, ScheduledJob.STATUS_COMPLETE)
-        self.assertEqual(result_job1.return_value, u'4.0')
+        job1.refresh_from_db()
+        self.assertEqual(job1.status, ScheduledJob.STATUS_COMPLETE)
+        self.assertEqual(job1.return_value, u'4.0')
 
-        result_job2 = ScheduledJob.objects.get(pk=job2.pk)
-        self.assertEqual(result_job2.status, ScheduledJob.STATUS_COMPLETE)
-        self.assertEqual(result_job2.return_value, u'8.0')
+        job2.refresh_from_db()
+        self.assertEqual(job2.status, ScheduledJob.STATUS_COMPLETE)
+        self.assertEqual(job2.return_value, u'8.0')
 
-        self.assertLess(
-                result_job1.execution_start,
-                result_job2.execution_start)
+        self.assertLess(job1.execution_start, job2.execution_start)
 
     def test_run_jobs_complete(self):
-        job = schedule_job(datetime(1970, 1, 1), 'math.pow', args=(2, 3))
+        job = schedule_job(
+                self.now - timedelta(hours=1), 'math.pow', args=(2, 3))
         self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)
 
-        run_jobs(now=datetime(1970, 1, 2))
+        run_jobs(now=self.now)
 
-        result_job = ScheduledJob.objects.get(pk=job.pk)
-        self.assertEqual(result_job.status, ScheduledJob.STATUS_COMPLETE)
-        self.assertEqual(result_job.return_value, u'8.0')
+        job.refresh_from_db()
+        self.assertEqual(job.status, ScheduledJob.STATUS_COMPLETE)
+        self.assertEqual(job.return_value, u'8.0')
 
     def test_run_jobs_failed(self):
-        job = schedule_job(datetime(1970, 1, 1), 'math.pow')
+        job = schedule_job(
+                self.now - timedelta(hours=1), 'math.pow')
         self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)
 
         with self.assertRaises(TypeError):
-            run_jobs(now=datetime(1970, 1, 2))
+            run_jobs(now=self.now)
 
-        result_job = ScheduledJob.objects.get(pk=job.pk)
-        self.assertEqual(result_job.status, ScheduledJob.STATUS_FAILED)
+        job.refresh_from_db()
+        self.assertEqual(job.status, ScheduledJob.STATUS_FAILED)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import timedelta
 
+from django.utils import timezone
 from django.test import TestCase
 
 from django_future.models import ScheduledJob
@@ -7,8 +8,12 @@ from django_future.models import ScheduledJob
 
 class ModelTestCase(TestCase):
 
+    def setUp(self):
+        self.now = timezone.now()
+
     def test_default_status(self):
+        start = self.now
+        end = self.now + timedelta(days=7)
         job = ScheduledJob.objects.create(
-                time_slot_start=datetime(1970, 1, 1),
-                time_slot_end=datetime(1970, 1, 2))
+                time_slot_start=start, time_slot_end=end)
         self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,10 +10,21 @@ class ModelTestCase(TestCase):
 
     def setUp(self):
         self.now = timezone.now()
+        self.start = self.now
+        self.end = self.now + timedelta(days=7)
 
     def test_default_status(self):
-        start = self.now
-        end = self.now + timedelta(days=7)
         job = ScheduledJob.objects.create(
-                time_slot_start=start, time_slot_end=end)
+                time_slot_start=self.start, time_slot_end=self.end)
         self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)
+
+    def test_repr(self):
+        job = ScheduledJob.objects.create(
+                time_slot_start=self.start,
+                time_slot_end=self.end,
+                callable_name="func")
+
+        self.assertEqual(
+            "<ScheduledJob (scheduled) callable='func'>",
+            repr(job)
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = {py27,py36}-django{110,111}
+
+[testenv]
+basepython =
+    py27: python2.7
+    py36: python3.6
+deps =
+    coverage
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+commands = coverage run runtests.py


### PR DESCRIPTION
I spent some time on django-future this afternoon after this morning's production issue. My goal was to improve the testing setup. I've added tests for management command (runscheduledjobs) and got the tests running automatically on Travis CI using tox. It tests Python 2.7, 3.6 with Django 1.10 and 1.11.

In addition I removed the code which ensures the DB driver is running in autocommit mode. This was not working with sqlite (though it should). It is the Django default and I don't see any danger without this explicit check.

To get the Python 3 tests to pass I did some initial work on supporting Python 3.