### PR TITLE
Fix migrations to work properly with Python 2 and 3

### DIFF
--- a/src/django_future/migrations/0001_initial.py
+++ b/src/django_future/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('time_slot_start', models.DateTimeField(verbose_name='time slot start')),
                 ('time_slot_end', models.DateTimeField(verbose_name='time slot end')),
                 ('execution_start', models.DateTimeField(null=True, verbose_name='execution start', blank=True)),
-                ('status', models.CharField(default=b'scheduled', max_length=32, verbose_name='status', choices=[(b'scheduled', 'Scheduled'), (b'running', 'Running'), (b'failed', 'Failed'), (b'complete', 'Complete'), (b'expired', 'Expired')])),
+                ('status', models.CharField(default='scheduled', max_length=32, verbose_name='status', choices=[('scheduled', 'Scheduled'), ('running', 'Running'), ('failed', 'Failed'), ('complete', 'Complete'), ('expired', 'Expired')])),
                 ('object_id', models.PositiveIntegerField(null=True, verbose_name='object ID', blank=True)),
                 ('callable_name', models.CharField(help_text='The callable to be executed may be specified in two ways: Set the callable name to an identifier (mypackage.myapp.some_function). Or specify an instance of a model as the content object and set the callable name to a method name (do_job).', max_length=255, verbose_name='callable name')),
                 ('args', picklefield.fields.PickledObjectField(verbose_name='args', editable=False)),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,22 +9,20 @@ from django_future.models import ScheduledJob
 class ModelTestCase(TestCase):
 
     def setUp(self):
-        self.now = timezone.now()
-        self.start = self.now
-        self.end = self.now + timedelta(days=7)
+        start = timezone.now()
+        end = start + timedelta(days=7)
+
+        self.job = ScheduledJob.objects.create(
+            time_slot_start=start, time_slot_end=end,
+            callable_name="func", args=(), kwargs={})
 
     def test_default_status(self):
-        job = ScheduledJob.objects.create(
-                time_slot_start=self.start, time_slot_end=self.end)
-        self.assertEqual(job.status, ScheduledJob.STATUS_SCHEDULED)
+        self.assertEqual(
+            self.job.status,
+            ScheduledJob.STATUS_SCHEDULED)
 
     def test_repr(self):
-        job = ScheduledJob.objects.create(
-                time_slot_start=self.start,
-                time_slot_end=self.end,
-                callable_name="func")
-
         self.assertEqual(
             "<ScheduledJob (scheduled) callable='func'>",
-            repr(job)
+            repr(self.job)
         )


### PR DESCRIPTION
Due to the fact that Python 3 handles string comparison differently: `b'x' != u'x'`, Django wants to "migrate" from byte strings to unicode strings. This is easily solved by removing the `b` string prefixes in the migrations.

In addition, the model unit tests were failing due to NOT NULL constraint errors raised by SQLite. I've refactored those tests a bit to fix them.