### PR TITLE
Support for Django 2.2.x only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
  - "3.6"
 
 env:
- - DJANGO_ENV=django111
  - DJANGO_ENV=django2
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-future',
-    version='0.3.0',
+    version='0.4.0',
     description='Scheduled jobs in Django',
     long_description=open('README').read(),
     author='Shrubbery Software',

--- a/src/django_future/admin.py
+++ b/src/django_future/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from django_future.models import ScheduledJob
@@ -17,14 +18,15 @@ class ScheduledJobAdmin(admin.ModelAdmin):
     }
 
     def colorful_status(self, obj):
-        color = self.status_colors['default']
         if obj.status in self.status_colors:
             color = self.status_colors[obj.status]
-        return '<strong style="color: %s">%s</strong>' % (
-                color, obj.get_status_display())
-
+        else:
+            color = self.status_colors['default']
+        return format_html(
+            '<strong style="color: {0}">{1}</strong>',
+            color, obj.get_status_display()
+        )
     colorful_status.short_description = 'Status'
-    colorful_status.allow_tags = True
 
     list_display = (
         'time_slot_start',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py36-django111,py36-django2
+envlist = py36-django2
 
 [testenv]
 basepython =
     py36: python3.6
 deps =
     coverage
-    django111: Django>=1.11,<2.0
-    django2: Django>=2.0,<3.0
+    django2: Django>=2.2,<3.0
 commands = coverage run runtests.py


### PR DESCRIPTION
Support for Django 1.11 is dropped. Only Django 2.2.x is now supported.

Version is bumped to v0.4.0.